### PR TITLE
Add Light classes to Cafe lib

### DIFF
--- a/source/javascripts/app/main.js.coffee
+++ b/source/javascripts/app/main.js.coffee
@@ -10,21 +10,21 @@ shaders =
                  uniform highp mat4 projectionMatrix;
                  uniform highp mat4 normalMatrix;
 
+                 uniform vec3 ambientColor;
+                 uniform vec3 directionalColor;
+                 uniform vec3 directionalVector;
+
                  varying highp vec2 vTextureCoord;
                  varying highp vec3 vLighting;
 
                  void main(void) {
                      gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPos, 1);
+
                      // apply lighting effect
-                     highp vec3 ambientLight = vec3(0.3, 0.3, 0.3);
-                     highp vec3 directionalLightColor = vec3(0.75, 0.75, 0.75);
-                     highp vec3 directionalVector = vec3(0.85, 0.80, 0.75);
-
                      highp vec4 transformedNormal = normalMatrix * vec4(normalPos, 1.0);
-
                      highp float directional = max(dot(transformedNormal.xyz, directionalVector), 0.0);
 
-                     vLighting = ambientLight + (directionalLightColor * directional);
+                     vLighting = ambientColor + (directionalColor * directional);
                      vTextureCoord = texCoord;
                  }
                  """
@@ -54,6 +54,11 @@ vertexBuffer    = null
 normalBuffer    = null
 
 texture = null
+ambientColor = new Cafe.Color(0.3, 0.3, 0.3)
+direction = vec3.fromValues(0.5, 1, 1)
+directionalLight = new Cafe.DirectionalLight(
+  new Cafe.Color(0.8, 1.0, 0.8), vec3.normalize(direction, direction)
+)
 
 program = null
 
@@ -96,6 +101,9 @@ render = (context, canvas) ->
   mat4.transpose(normalMatrix, normalMatrix)
   program.uniformMatrix4fv("normalMatrix", normalMatrix)
 
+  program.uniform3f("ambientColor", ambientColor)
+  program.uniform3f("directionalColor", directionalLight.color)
+  program.uniform3fv("directionalVector", directionalLight.direction)
   program.bindTexture("uSampler", texture)
 
   context.drawTriangles(indexBuffer.size)

--- a/source/libs/javascripts/cafe/directional_light.js.coffee
+++ b/source/libs/javascripts/cafe/directional_light.js.coffee
@@ -1,0 +1,3 @@
+namespace 'Cafe', (exports) ->
+  class exports.DirectionalLight
+    constructor: (@color, @direction) ->

--- a/source/libs/javascripts/cafe/light.js.coffee
+++ b/source/libs/javascripts/cafe/light.js.coffee
@@ -1,0 +1,3 @@
+namespace 'Cafe', (exports) ->
+  class exports.AmbientLight
+    constructor: (@color) ->

--- a/source/libs/javascripts/cafe/program.js.coffee
+++ b/source/libs/javascripts/cafe/program.js.coffee
@@ -11,6 +11,14 @@ namespace 'Cafe', (exports) ->
       uniform = @uniformLocation(uniformName)
       @gl.uniformMatrix4fv(uniform, false, matrix);
 
+    uniform3f: (uniformName, color) ->
+      uniform = @uniformLocation(uniformName)
+      @gl.uniform3f(uniform, color.red, color.green, color.blue)
+
+    uniform3fv: (uniformName, vector) ->
+      uniform = @uniformLocation(uniformName)
+      @gl.uniform3fv(uniform, vector)
+
     bindVertexBuffer: (attribName, vertexBuffer) ->
       attribute = @getAttribLocation(attribName)
       @gl.enableVertexAttribArray(attribute)


### PR DESCRIPTION
Adds classes for ambient and basic directional lights.
- directional light is set as input for vertex shader
- ambient color is set as input argument for shader
